### PR TITLE
Add Option to Load TensorRT Engine Directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ It makes use of my other project [tensorrt-cpp-api](https://github.com/cyrusbehr
 - To run inference on an image and save the annotated image to disk run: `./detect_object_image --model /path/to/your/onnx/model.onnx --input /path/to/your/image.jpg`
   - You can use the images in the `images/` directory for testing
 - To run inference using your webcam and display the results in real time, run: `./detect_object_video --model /path/to/your/onnx/model.onnx --input 0`
+- Note: You can also specify a TensorRT engine file by using the `--trt_model` option if you have a pre-built TensorRT engine available.
 - For a full list of arguments, run any of the executables without providing any arguments.
 
 ### INT8 Inference

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -6,15 +6,16 @@
 int main(int argc, char *argv[]) {
     YoloV8Config config;
     std::string onnxModelPath;
+    std::string trtModelPath;
     std::string inputImage;
 
     // Parse the command line arguments
-    if (!parseArguments(argc, argv, config, onnxModelPath, inputImage)) {
+    if (!parseArguments(argc, argv, config, onnxModelPath, trtModelPath, inputImage)) {
         return -1;
     }
 
     // Create the YoloV8 engine
-    YoloV8 yoloV8(onnxModelPath, config);
+    YoloV8 yoloV8(onnxModelPath, trtModelPath, config);
 
     // Read the input image
     auto img = cv::imread(inputImage);

--- a/src/object_detection_image.cpp
+++ b/src/object_detection_image.cpp
@@ -5,15 +5,16 @@
 int main(int argc, char *argv[]) {
     YoloV8Config config;
     std::string onnxModelPath;
+    std::string trtModelPath;
     std::string inputImage;
 
     // Parse the command line arguments
-    if (!parseArguments(argc, argv, config, onnxModelPath, inputImage)) {
+    if (!parseArguments(argc, argv, config, onnxModelPath, trtModelPath, inputImage)) {
         return -1;
     }
 
     // Create the YoloV8 engine
-    YoloV8 yoloV8(onnxModelPath, config);
+    YoloV8 yoloV8(onnxModelPath, trtModelPath, config);
 
     // Read the input image
     auto img = cv::imread(inputImage);

--- a/src/object_detection_video_stream.cpp
+++ b/src/object_detection_video_stream.cpp
@@ -6,15 +6,16 @@
 int main(int argc, char *argv[]) {
     YoloV8Config config;
     std::string onnxModelPath;
+    std::string trtModelPath;
     std::string inputVideo;
 
     // Parse the command line arguments
-    if (!parseArgumentsVideo(argc, argv, config, onnxModelPath, inputVideo)) {
+    if (!parseArgumentsVideo(argc, argv, config, onnxModelPath, trtModelPath, inputVideo)) {
         return -1;
     }
 
     // Create the YoloV8 engine
-    YoloV8 yoloV8(onnxModelPath, config);
+    YoloV8 yoloV8(onnxModelPath, trtModelPath, config);
 
     // Initialize the video stream
     cv::VideoCapture cap;

--- a/src/yolov8.h
+++ b/src/yolov8.h
@@ -61,7 +61,7 @@ struct YoloV8Config {
 class YoloV8 {
 public:
     // Builds the onnx model into a TensorRT engine, and loads the engine into memory
-    YoloV8(const std::string &onnxModelPath, const YoloV8Config &config);
+    YoloV8(const std::string &onnxModelPath, const std::string &trtModelPath, const YoloV8Config &config);
 
     // Detect the objects in the image
     std::vector<Object> detectObjects(const cv::Mat &inputImageBGR);


### PR DESCRIPTION
This pull request introduces an option to load a pre-built TensorRT engine directly, addressing an issue encountered while using the YOLOv8n ONNX model.

**Problem:**
While building the TensorRT engine from the YOLOv8n onnx file, I experienced a "core dumped" error. However, I was able to build the engine successfully using the trtexec command-line tool.

**Solution:**
I added a new command-line argument (--trt_model) to specify a pre-built TensorRT engine file. When this option is provided, the application loads the TensorRT engine directly, bypassing the ONNX model conversion.

**Changes Made:**
- Introduced --trt_model argument for loading TensorRT engines.
- Updated argument parsing logic and YoloV8 constructor.
- Revised documentation to include this new feature.