### PR TITLE
CSI camera on the Jetson Orin Nano using gstreamer in OpenCV

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,3 +37,6 @@ target_link_libraries(benchmark YoloV8_TRT)
 
 add_executable(detect_object_video src/object_detection_video_stream.cpp)
 target_link_libraries(detect_object_video YoloV8_TRT)
+
+add_executable(detect_object_csi_jetson src/object_detection_csi_jetson.cpp)
+target_link_libraries(detect_object_csi_jetson YoloV8_TRT)

--- a/src/object_detection_csi_jetson.cpp
+++ b/src/object_detection_csi_jetson.cpp
@@ -1,0 +1,58 @@
+#include "cmd_line_util.h"
+#include "yolov8.h"
+#include <opencv2/cudaimgproc.hpp>
+
+// Runs object detection on video stream then displays annotated results.
+int main(int argc, char *argv[]) {
+    YoloV8Config config;
+    std::string onnxModelPath;
+    std::string trtModelPath;
+    std::string inputVideo;
+
+    // Parse the command line arguments
+    if (!parseArgumentsVideo(argc, argv, config, onnxModelPath, trtModelPath, inputVideo)) {
+        return -1;
+    }
+
+    // Create the YoloV8 engine
+    YoloV8 yoloV8(onnxModelPath, trtModelPath, config);
+
+    // Define GStreamer pipeline for the CSI camera
+    std::string gst_pipeline = 
+        "nvarguscamerasrc ! video/x-raw(memory:NVMM), "
+        "width=1280, height=720, framerate=30/1 ! nvvidconv ! "
+        "video/x-raw, format=(string)BGRx ! videoconvert ! "
+        "video/x-raw, format=(string)BGR ! appsink drop=true sync=false";
+
+    // Open the CSI camera
+    cv::VideoCapture cap(gst_pipeline, cv::CAP_GSTREAMER);
+
+    if (!cap.isOpened()) {
+        std::cerr << "Error: Cannot open CSI camera" << std::endl;
+        return -1;
+    }
+
+    std::cout << "CSI Camera opened successfully!" << std::endl;
+
+    while (true) {
+        // Grab frame
+        cv::Mat img;
+        cap >> img;
+
+        if (img.empty())
+            throw std::runtime_error("Unable to decode image from video stream.");
+
+        // Run inference
+        const auto objects = yoloV8.detectObjects(img);
+
+        // Draw the bounding boxes on the image
+        yoloV8.drawObjectLabels(img, objects);
+
+        // Display the results
+        cv::imshow("Object Detection", img);
+        if (cv::waitKey(1) >= 0)
+            break;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
# Change Description

Example was added to use the yolo model on a CSI camera stream using a gstreamer pipeline in opencv.  Tested on the Jetson Orin Nano.  Also added a cmake compiler flag so that the program can be run with the GDB debugger if desired.  While I tested on my CSI camera on my jetson, any camera that can be be accessed using gstreamer or another method in OpenCV should work.

## Requirements:

1. First installed gstreamer (wasn't installed in the docker container I tested in, though typically it's already installed on the host jetson nano outside of a container - for reference I used this container nvcr.io/nvidia/l4t-jetpack:r36.4.0 which had the requirements of this repo for cuda and tensorrt and cudnn)

```
sudo apt install -y libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-good1.0-dev
# don't use sudo in the docker container if you're using one
```

2. Install OpenCV using `WITH_GSTREAMER=ON` and `WITH_GSTREAMER_1_0=ON` in your cmake settings after installing gstreamer (that way opencv links it to the build).  I used this script to install opencv: https://github.com/crose72/Install-OpenCV-Jetson-Nano/blob/main/OpenCV-4-10-0-tracking.sh.

## How to Run

To run the program, follow the instructions in the readme to compile it like normal using `cmake ..` and `make -j$(nproc)` and then execute

```
./detect_object_csi_jetson --model ../../yolov8s.onnx --input 0
```
My yolo onnx file was two directories above the build folder so that's the reason for my model path.  The input still has to be there because the `parseArgumentsVideo` function requires it, and we still want to specify the path of the yolo model.